### PR TITLE
feat: allow user to set mailbox capacity via `Owner::build`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
   #[error("worker gone")]
   WorkerGone,


### PR DESCRIPTION
Added `Owner::build` which returns a builder.

```rust
 let owner = Owner::build().mailbox_capacity(1).start(A);
```

Closes #1 